### PR TITLE
Add retrieval API for alignment manuals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,75 @@
-# sat-rag
+# Alignment Manual Chatbot API
+
+This repository provides a FastAPI service that answers questions about multiple
+sequence alignment tools using a lightweight retrieval pipeline. The knowledge
+base ships with curated manuals for MAFFT, UCLUST/USEARCH and VSEARCH, enabling a
+chatbot-style interface that responds with relevant excerpts.
+
+## Features
+
+- ✅ Retrieval-augmented question answering across custom documentation.
+- ✅ FastAPI endpoint for integration with web front-ends (such as the companion React UI).
+- ✅ TF–IDF vector search with multi-paragraph chunking.
+- ✅ Simple health check endpoint for monitoring.
+- ✅ Pytest coverage for the retrieval core.
+
+## Project layout
+
+```
+app/
+  main.py          # FastAPI application entry point
+  rag.py           # Retrieval and QA engine implementation
+scripts/
+  fetch_docs.py    # (Optional) helper for downloading manuals from the web
+data/
+  *.txt            # Curated documentation used by the RAG engine
+```
+
+## Getting started
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Run the API locally (reload enabled):
+
+```bash
+uvicorn app.main:app --reload
+```
+
+Example request:
+
+```bash
+curl -X POST http://localhost:8000/query \
+  -H 'Content-Type: application/json' \
+  -d '{"question": "How do I enable iterative refinement in MAFFT?"}'
+```
+
+Example response:
+
+```json
+{
+  "question": "How do I enable iterative refinement in MAFFT?",
+  "answer": "Here is what the manuals cover:\n- MAFFT Multiple Sequence Alignment Manual (summary): --linsi — L-INS-i algorithm; uses local pairwise alignment information and iterative refinement. High accuracy for a moderate number of sequences. --ginsi — G-INS-i algorithm; global homology assumption. Effective for sequences with uniform lengths.",
+  "sources": ["mafft_manual.txt"],
+  "matches": [
+    {
+      "title": "MAFFT Multiple Sequence Alignment Manual (summary)",
+      "source": "mafft_manual.txt",
+      "score": 0.42,
+      "content": "..."
+    }
+  ]
+}
+```
+
+Run tests:
+
+```bash
+pytest
+```
+
+The service can be paired with the existing React/Vite front-end by pointing its
+API requests to the `/query` endpoint exposed here.

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,60 @@
+"""FastAPI application exposing a retrieval-based chatbot API."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+
+from .rag import KnowledgeBase, QAEngine
+
+DATA_DIR = Path(__file__).resolve().parents[1] / "data"
+
+app = FastAPI(title="Alignment Manual Chatbot", version="0.1.0")
+
+
+class QueryRequest(BaseModel):
+    question: str = Field(..., description="Natural language question to answer.")
+    top_k: int = Field(3, ge=1, le=10, description="Number of supporting passages to return.")
+
+
+class Match(BaseModel):
+    title: str
+    source: str
+    score: float
+    content: str
+
+
+class QueryResponse(BaseModel):
+    question: str
+    answer: str
+    sources: List[str]
+    matches: List[Match]
+
+
+@app.on_event("startup")
+async def load_knowledge_base() -> None:
+    """Load manuals into memory when the service starts."""
+    try:
+        app.state.kb = KnowledgeBase(DATA_DIR)
+        app.state.kb.load()
+        app.state.qa = QAEngine(app.state.kb)
+    except Exception as exc:  # pragma: no cover - startup failure should bubble up
+        raise RuntimeError(f"Failed to initialise knowledge base: {exc}") from exc
+
+
+@app.post("/query", response_model=QueryResponse)
+async def query_manuals(request: QueryRequest) -> QueryResponse:
+    if not request.question.strip():
+        raise HTTPException(status_code=400, detail="Question must not be empty.")
+    engine: QAEngine = app.state.qa
+    result = engine.answer(request.question, top_k=request.top_k)
+    return QueryResponse(**result)
+
+
+@app.get("/healthz")
+async def healthcheck() -> dict:
+    """Simple health endpoint for monitoring."""
+    status = "ready" if hasattr(app.state, "qa") else "initialising"
+    return {"status": status}

--- a/app/rag.py
+++ b/app/rag.py
@@ -1,0 +1,168 @@
+"""Simple retrieval-augmented QA over alignment manuals."""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Sequence
+
+import numpy as np
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.metrics.pairwise import cosine_similarity
+
+
+@dataclass
+class DocumentChunk:
+    """A chunk of documentation used for retrieval."""
+
+    title: str
+    content: str
+    source: str
+    order: int
+
+
+class KnowledgeBase:
+    """Load documentation text files and expose searchable chunks."""
+
+    def __init__(self, data_dir: Path, chunk_size: int = 800, overlap: int = 120) -> None:
+        self.data_dir = data_dir
+        self.chunk_size = chunk_size
+        self.overlap = overlap
+        self.chunks: List[DocumentChunk] = []
+        self._vectorizer: TfidfVectorizer | None = None
+        self._matrix = None
+
+    def load(self) -> None:
+        files = sorted(self.data_dir.glob("*.txt"))
+        order = 0
+        for path in files:
+            text = path.read_text(encoding="utf-8")
+            paragraphs = split_paragraphs(text)
+            chunk_id = 0
+            for chunk in chunk_paragraphs(paragraphs, self.chunk_size, self.overlap):
+                title = derive_title(chunk, path.stem, chunk_id)
+                self.chunks.append(
+                    DocumentChunk(title=title, content=chunk, source=path.name, order=order)
+                )
+                order += 1
+                chunk_id += 1
+        if not self.chunks:
+            raise ValueError(f"No documentation found in {self.data_dir}")
+        self._fit()
+
+    def _fit(self) -> None:
+        texts = [chunk.content for chunk in self.chunks]
+        self._vectorizer = TfidfVectorizer(
+            stop_words="english", ngram_range=(1, 2), min_df=1
+        )
+        self._matrix = self._vectorizer.fit_transform(texts)
+
+    def search(self, query: str, top_k: int = 3) -> Sequence[tuple[DocumentChunk, float]]:
+        if not query.strip():
+            return []
+        if self._vectorizer is None or self._matrix is None:
+            raise RuntimeError("Knowledge base has not been loaded")
+        query_vec = self._vectorizer.transform([query])
+        scores = cosine_similarity(query_vec, self._matrix).ravel()
+        if not np.any(scores):
+            return []
+        top_indices = scores.argsort()[::-1][:top_k]
+        results = []
+        for idx in top_indices:
+            results.append((self.chunks[int(idx)], float(scores[int(idx)])))
+        return results
+
+
+class QAEngine:
+    """High-level question answering engine using TF-IDF retrieval."""
+
+    def __init__(self, knowledge_base: KnowledgeBase) -> None:
+        self.knowledge_base = knowledge_base
+
+    def answer(self, question: str, top_k: int = 3) -> dict:
+        hits = self.knowledge_base.search(question, top_k=top_k)
+        if not hits:
+            return {
+                "question": question,
+                "answer": "I could not find relevant information in the manuals.",
+                "sources": [],
+                "matches": [],
+            }
+        summary_lines = [
+            f"- {hit.title}: {summarise_text(hit.content)}" for hit, _ in hits
+        ]
+        answer = "Here is what the manuals cover:\n" + "\n".join(summary_lines)
+        return {
+            "question": question,
+            "answer": answer,
+            "sources": [hit.source for hit, _ in hits],
+            "matches": [
+                {
+                    "title": hit.title,
+                    "source": hit.source,
+                    "score": score,
+                    "content": hit.content,
+                }
+                for hit, score in hits
+            ],
+        }
+
+
+def split_paragraphs(text: str) -> List[str]:
+    """Split text into non-empty paragraphs."""
+    parts = [part.strip() for part in re.split(r"\n\s*\n", text)]
+    return [part for part in parts if part]
+
+
+def chunk_paragraphs(paragraphs: Iterable[str], chunk_size: int, overlap: int) -> List[str]:
+    """Combine neighbouring paragraphs into overlapping chunks of roughly chunk_size characters."""
+    chunks: List[str] = []
+    buffer: List[str] = []
+    total = 0
+    for para in paragraphs:
+        para_len = len(para)
+        if total + para_len > chunk_size and buffer:
+            chunks.append("\n\n".join(buffer))
+            # Start a new buffer retaining trailing paragraphs for overlap
+            if overlap > 0:
+                buffer = paragraph_tail(buffer, overlap)
+            else:
+                buffer = []
+            total = sum(len(part) for part in buffer)
+        buffer.append(para)
+        total += para_len
+    if buffer:
+        chunks.append("\n\n".join(buffer))
+    return chunks
+
+
+def paragraph_tail(buffer: Sequence[str], target_chars: int) -> List[str]:
+    """Return the trailing paragraphs whose combined length is at least target_chars."""
+    if target_chars <= 0:
+        return []
+    selected: List[str] = []
+    total = 0
+    for paragraph in reversed(buffer):
+        selected.append(paragraph)
+        total += len(paragraph)
+        if total >= target_chars:
+            break
+    return list(reversed(selected))
+
+
+def derive_title(chunk: str, fallback: str, chunk_id: int) -> str:
+    """Generate a short title for a chunk using the first heading-like line."""
+    if chunk:
+        first_line = chunk.splitlines()[0]
+        if first_line and len(first_line) < 120:
+            return first_line.strip()
+    return f"{fallback} section {chunk_id + 1}"
+
+
+def summarise_text(text: str, max_sentences: int = 2) -> str:
+    """Return the first couple of sentences for reporting."""
+    sentences = re.split(r"(?<=[.!?])\s+", text.strip())
+    sentences = [sentence.strip() for sentence in sentences if sentence.strip()]
+    if not sentences:
+        return text.strip()
+    return " ".join(sentences[:max_sentences])

--- a/data/mafft_manual.txt
+++ b/data/mafft_manual.txt
@@ -1,0 +1,104 @@
+MAFFT Multiple Sequence Alignment Manual (summary)
+================================================
+
+Overview
+--------
+MAFFT is a fast multiple sequence alignment program supporting a variety of
+alignment strategies optimized for nucleotide and protein sequences of different
+lengths and divergence levels. The main executable is `mafft` and accepts
+numerous command-line options to tune alignment accuracy, runtime and memory
+consumption.
+
+Core usage patterns
+-------------------
+Run MAFFT by providing an input FASTA file. The default output is written to
+STDOUT unless `--output` or shell redirection is used.
+
+```
+mafft [options] input.fasta > aligned.fasta
+```
+
+Automatic strategy selection
+----------------------------
+* `--auto` — Analyse the dataset and automatically select an appropriate
+  algorithm (FFT-NS-2, L-INS-i, G-INS-i, etc.). Suitable starting point for most
+  datasets.
+* `--6merpair` — Use 6-mer distance for the progressive alignment phase (default
+  for protein sequences).
+* `--retree <n>` — Recompute the guide tree `n` times to refine the alignment.
+
+Progressive FFT-NS methods (fast)
+---------------------------------
+* `--globalpair` — Global pairwise alignment using Needleman–Wunsch dynamic
+  programming. Accurate for full-length homologs, slower than default.
+* `--localpair` — Local pairwise alignment using Smith–Waterman. Recommended for
+  sequences with conserved motifs and large indels.
+* `--genafpair` — Genomic alignment using a Fourier transform approach with
+  anchors; handles long sequences with repeats.
+* `--maxiterate <n>` — Perform iterative refinement up to `n` cycles. `--maxiterate 0`
+  disables refinement (fastest). Typical values: 100 or 1000 for high accuracy.
+
+Iterative refinement methods (accurate)
+---------------------------------------
+* `--linsi` — L-INS-i algorithm; uses local pairwise alignment information and
+  iterative refinement. High accuracy for a moderate number of sequences.
+* `--ginsi` — G-INS-i algorithm; global homology assumption. Effective for
+  sequences with uniform lengths.
+* `--einsi` — E-INS-i algorithm; handles sequences with multiple conserved
+  domains and large unalignable regions.
+* `--qinsi` — Q-INS-i algorithm for RNA sequences, uses secondary structure
+  information from base-pairing probabilities. Requires `--rna` or RNA input.
+
+Input and output options
+------------------------
+* `--thread <n>` — Number of CPU threads. The default is 1.
+* `--anysymbol` — Allow unusual residue characters without treating them as
+  gaps.
+* `--preservecase` — Preserve lower/upper-case characters in the output.
+* `--inputorder` — Keep the input sequence order in the output alignment.
+* `--reorder` — Reorder sequences in the output based on the guide tree.
+* `--treeout` — Write the guide tree to `<input>.tree`.
+* `--quiet` — Suppress progress reporting.
+* `--clustalout` — Write alignment in Clustal format instead of FASTA.
+
+Handling large datasets
+-----------------------
+* `--parttree` — Use the PartTree algorithm to construct an approximate guide
+  tree for very large datasets; reduces memory usage.
+* `--partsize <n>` — Control the size of sub-alignments when using `--parttree`.
+* `--leavegappyregion` — Avoid trimming gappy regions during iterative
+  refinement, useful for sequencing reads.
+* `--add` / `--addfragments` — Add new sequences to an existing alignment.
+* `--keeplength` — Keep alignment length unchanged when adding fragments.
+
+Scoring adjustments
+-------------------
+* `--op <float>` — Gap opening penalty (default ~1.53 for proteins, 1.0 for DNA).
+* `--ep <float>` — Offset (gap extension) penalty. Lower values allow longer gaps.
+* `--lop` / `--lep` — Late phase gap open/extend penalties used during
+  refinement.
+* `--bl <matrix>` — Use specified scoring matrix (`BLOSUM62`, `JTT200`, etc.).
+* `--kimura 1` — Apply Kimura correction for nucleotide distances.
+
+RNA-specific options
+--------------------
+* `--rna` — Interpret input as RNA; convert T to U in scoring.
+* `--clustalout --qinsi --ep 0` — Typical settings for structural RNA alignment
+  when pairing probabilities are provided.
+
+Quality assessment
+------------------
+* `--summary <file>` — Output per-sequence score summary.
+* `--hash <size>` — Hash table size for FFT; increasing can reduce collisions.
+* `--op 1.0 --ep 0.1 --maxiterate 1000` — Balanced high-accuracy profile for
+  small data sets.
+
+Troubleshooting tips
+--------------------
+* Memory errors often occur when aligning genomes without `--parttree`.
+* Use `--reorder` for best accuracy; combine with `--inputorder` if original
+  order is important.
+* For extremely divergent sequences, `--globalpair --maxiterate 1000` improves
+  alignment quality but increases runtime.
+* Remove extremely short fragments or use `--addfragments` to avoid forcing them
+  into the full-length alignment.

--- a/data/usearch_uclust_manual.txt
+++ b/data/usearch_uclust_manual.txt
@@ -1,0 +1,89 @@
+UCLUST (USEARCH) Command Summary
+================================
+
+Overview
+--------
+UCLUST is a greedy clustering algorithm implemented in the USEARCH toolkit. It
+performs sequence clustering, chimera detection, OTU picking and related tasks
+for microbial amplicon pipelines. USEARCH commands are invoked with
+`usearch <command> <arguments>`.
+
+Common global options
+---------------------
+* `--threads <n>` — Number of worker threads (default 1).
+* `--log <file>` — Write a detailed log file of the run.
+* `--quiet` — Reduce progress output.
+* `--notmatched <fasta>` — Write sequences that failed a search to a FASTA file.
+* `--matched <fasta>` — Write sequences that produced hits to a FASTA file.
+* `--uc <file>` — Generate a tab-delimited cluster assignment file.
+
+Dereplication and sorting
+-------------------------
+* `-derep_fulllength <in> -output <out>` — Merge identical sequences, keeping
+  abundance counts in headers.
+* `-sizeout` — Append size annotations (`;size=NN;`) in FASTA headers.
+* `-minseqlength <n>` — Discard sequences shorter than `n` bp.
+* `-sortbysize <in> -output <out>` — Sort sequences descending by abundance.
+* `-sortbylength <in> -output <out>` — Sort sequences descending by length.
+
+Clustering commands
+-------------------
+* `-cluster_fast <in> -id <0-1> -centroids <out>` — Greedy clustering of
+  sequences sorted by decreasing abundance. Recommended workflow after
+  dereplication.
+* `-cluster_smallmem <in> -id <0-1> -centroids <out>` — Memory-conservative
+  clustering for very large datasets. Requires sequences sorted by length.
+* `-cluster_otus <in> -minsize <n> -otus <out>` — One-step OTU clustering with
+  chimera filtering at 97% identity by default.
+* `-cluster_unoise <in> -minsize <n> -unoise <out>` — Error-correct amplicons and
+  infer ZOTUs using the UNOISE algorithm.
+* `-alpha_div <in> -output <out>` — Calculate alpha diversity metrics from OTU
+  tables.
+
+Chimera filtering
+-----------------
+* `-uchime_ref <in> -db <ref> -strand both -nonchimeras <out>` — Detect chimeras
+  against a reference database using UCHIME.
+* `-uchime_denovo <in> -nonchimeras <out>` — Reference-free chimera detection.
+* `-uchime3_denovo` — UNOISE3 chimera detection tuned for Illumina reads.
+* Important parameters: `-mindiffs`, `-xn`, `-minh`, `-mindiv` control decision
+  thresholds.
+
+Searching and OTU assignment
+----------------------------
+* `-usearch_global <query> -db <ref> -id <0-1> -strand both -otutabout <out>` —
+  Global alignment search for OTU picking or taxonomy assignment.
+* `-search_exact <query> -db <ref>` — Exact string matching for barcode mapping.
+* `-usearch_local` — Local alignment search allowing mismatches and indels.
+* `-fastx_uniques <in> -fastaout <out>` — Dereplicate nucleotide sequences using
+  quality-aware heuristics.
+* `-fastq_filter <in.fastq> -fastqout <out.fastq> -fastq_maxee <max>` — Filter
+  reads by expected error.
+
+Quality filtering and preprocessing
+-----------------------------------
+* `-fastq_maxee <n>` — Maximum expected errors per read.
+* `-fastq_minlen <n>` — Minimum length after trimming.
+* `-fastq_truncqual <q> -fastq_trunclen <L>` — Trim reads at first base with
+  quality `<q>` or to length `<L>`.
+* `-fastx_revcomp` — Reverse complement FASTA/FASTQ sequences.
+* `-fastq_stats` — Summarise read quality statistics.
+
+OTU tables and taxonomy
+-----------------------
+* `-otutab <reads> -otus <otus> -otutabout <table>` — Create an OTU read count
+  table using global search.
+* `-otutab_norm` — Normalize OTU table counts to a specified depth.
+* `-sintax <query> -db <ref> -tabbedout <out> -strand both` — Taxonomic
+  annotation using the SINTAX classifier.
+* `-makeudb_usearch <ref.fasta>` — Create a database index for rapid searching.
+
+Troubleshooting and tips
+------------------------
+* Input files must be sorted appropriately for greedy clustering.
+* Use `-sizein` when reading dereplicated FASTA with `;size=NN;` annotations.
+* Identity thresholds around `0.97` mimic traditional OTUs; higher thresholds
+  (0.99) produce ASVs but require quality filtering.
+* UNOISE and UCHIME algorithms need minimum abundance (`-minsize`) to avoid
+  inflating spurious variants.
+* Keep FASTA headers simple; spaces terminate the identifier.

--- a/data/vsearch_manual.txt
+++ b/data/vsearch_manual.txt
@@ -1,0 +1,91 @@
+VSEARCH Command Reference
+=========================
+
+Overview
+--------
+VSEARCH is an open-source alternative to USEARCH implementing sequence search,
+clustering, chimera detection, and OTU/ASV generation for high-throughput
+amplicon pipelines. Commands follow the pattern `vsearch --command arguments`.
+
+General options
+---------------
+* `--threads <n>` — Number of CPU threads (default 1).
+* `--fastaprefix <string>` — Prefix headers in FASTA output.
+* `--log <file>` — Write verbose log output.
+* `--fasta_width <n>` — Set FASTA line width for output (default 80).
+* `--quiet` — Reduce console output.
+
+Input sanitation
+----------------
+* `--fastq_ascii <33|64>` — Specify FASTQ ASCII offset.
+* `--fastx_filter` — Filter FASTQ files by quality and length.
+* `--fastq_minlen`, `--fastq_maxlen` — Minimum/maximum length filters.
+* `--fastq_maxee <n>` — Maximum expected errors per read.
+* `--fastx_mask <in> --fastx_out <out>` — Mask low-complexity regions.
+* `--reverse`, `--reverse_complement` — Reverse orientation of sequences.
+
+Dereplication and sorting
+-------------------------
+* `--derep_fulllength <in> --output <out>` — Deduplicate sequences by full-length
+  identity, writing abundance annotations.
+* `--derep_prefix` — Deduplicate by prefix identity; useful for incremental
+  clustering.
+* `--minseqlength <n>` — Discard shorter sequences during dereplication.
+* `--sizeout` / `--sizein` — Control `;size=NN;` annotations in FASTA headers.
+* `--sortbysize <in> --output <out>` — Sort by abundance before clustering.
+* `--sortbylength` — Sort by length to optimise memory usage.
+
+Clustering and OTU picking
+--------------------------
+* `--cluster_fast <in> --id <0-1> --centroids <out>` — Greedy clustering using
+  abundance order (requires dereplicated input).
+* `--cluster_smallmem` — Memory-efficient clustering for large datasets.
+* `--cluster_size` — Abundance-weighted clustering emphasising dominant reads.
+* `--cluster_unoise` — UNOISE3 denoising to generate ZOTUs.
+* `--clusterout_id --clusters <prefix>` — Output separate FASTA per cluster.
+* `--iddef <1-4>` — Identity definition; 1=global pairwise, 2=alignment, etc.
+
+Searching and mapping
+---------------------
+* `--usearch_global <query> --db <ref> --id <0-1> --strand both` — Global search
+  for taxonomy or OTU assignment.
+* `--search_exact` — Exact match searching.
+* `--usearch_local` — Local alignment search.
+* `--align <query> --db <ref>` — Pairwise alignment reporting.
+* `--blast6out <file>` — Output search results in BLAST tabular format.
+
+Chimera detection
+-----------------
+* `--uchime_ref <in> --db <ref> --nonchimeras <out>` — Reference-based UCHIME
+  algorithm.
+* `--uchime_denovo <in> --nonchimeras <out>` — De novo chimera detection.
+* `--uchime3_denovo` — UNOISE3-tuned chimera removal for high-quality reads.
+* Key options: `--mindiv`, `--mindiffs`, `--minh`, `--xn`, `--dn` adjust
+  sensitivity.
+
+OTU/ASV tables
+--------------
+* `--otutab <reads> --otus <otus> --otutabout <table>` — Generate OTU table by
+  mapping reads to centroid sequences.
+* `--otutab_mindiv <n>` — Minimum divergence when assigning reads.
+* `--otutab_norm <depth>` — Rarefy OTU table to a fixed depth.
+* `--relabund` — Report relative abundance instead of raw counts.
+
+Additional utilities
+--------------------
+* `--fastq_mergepairs <forward> --reverse <reverse> --fastqout <out>` — Merge
+  paired-end reads with overlap scoring.
+* `--fastq_join` — Overlap-join FASTQ reads with simple heuristics.
+* `--msaout <file>` — Output alignments from search/cluster operations.
+* `--consout <file>` — Write consensus sequences per cluster.
+* `--qmask <none|soft|dust>` — Quality masking prior to clustering.
+* `--strand <both|plus|minus>` — Control strand search orientation.
+
+Best practices
+--------------
+* Always dereplicate and sort input before clustering for reproducible results.
+* Set `--id 0.97` for traditional OTUs; `0.99` or `1.0` for ASV-like resolution.
+* UNOISE algorithms require a minimum abundance threshold (default 8) to avoid
+  noise amplification.
+* Provide high-quality reference databases in FASTA for taxonomy (`--db`).
+* Inspect `.uc` files to audit cluster assignments and read reassignment.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+fastapi==0.110.2
+uvicorn[standard]==0.29.0
+scikit-learn==1.4.2
+numpy==1.26.4
+scipy==1.13.0
+beautifulsoup4==4.12.3
+requests==2.31.0
+pytest==8.3.3

--- a/scripts/fetch_docs.py
+++ b/scripts/fetch_docs.py
@@ -1,0 +1,50 @@
+"""Fetch reference manuals and store them as plain text files."""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import requests
+from bs4 import BeautifulSoup
+
+DATA_DIR = Path(__file__).resolve().parents[1] / "data"
+
+SOURCES = {
+    "mafft_manual.txt": "https://mafft.cbrc.jp/alignment/software/manual/manual.html",
+    "usearch_uclust_manual.txt": "https://drive5.com/usearch/manual/cmds_all.html",
+}
+
+
+def clean_text(text: str) -> str:
+    """Collapse repeated whitespace and normalise spacing."""
+    text = re.sub(r"\s+", " ", text)
+    text = re.sub(r" (?=[,.;:!?])", "", text)
+    text = re.sub(r"\s*\n\s*", "\n", text)
+    text = re.sub(r"\n{2,}", "\n\n", text)
+    return text.strip()
+
+
+
+def extract_plain_text(html: str) -> str:
+    soup = BeautifulSoup(html, "html.parser")
+    for tag in soup(["script", "style", "noscript"]):
+        tag.decompose()
+    text = soup.get_text("\n")
+    lines = [line.strip() for line in text.splitlines()]
+    filtered = [line for line in lines if line]
+    return clean_text("\n".join(filtered))
+
+
+
+def main() -> None:
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    for filename, url in SOURCES.items():
+        resp = requests.get(url, timeout=30)
+        resp.raise_for_status()
+        text = extract_plain_text(resp.text)
+        (DATA_DIR / filename).write_text(text, encoding="utf-8")
+        print(f"Saved {filename} from {url} ({len(text)} chars)")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+import pytest
+
+from app.rag import KnowledgeBase, QAEngine
+
+
+@pytest.fixture(scope="session")
+def qa_engine() -> QAEngine:
+    data_dir = Path(__file__).resolve().parents[1] / "data"
+    kb = KnowledgeBase(data_dir)
+    kb.load()
+    return QAEngine(kb)
+
+
+def test_search_returns_results(qa_engine: QAEngine) -> None:
+    response = qa_engine.answer("How do I run MAFFT with iterative refinement?", top_k=2)
+    assert response["sources"], "Expected at least one source"
+    assert "mafft" in " ".join(response["sources"]).lower()
+
+
+def test_empty_question_handled(qa_engine: QAEngine) -> None:
+    response = qa_engine.answer("   ")
+    assert "could not find" in response["answer"].lower()
+
+
+def test_vsearch_query(qa_engine: QAEngine) -> None:
+    response = qa_engine.answer("How do I run vsearch chimera detection?", top_k=2)
+    assert response["matches"], "Expected retrieval results for vsearch"
+    combined = " ".join(match["content"].lower() for match in response["matches"])
+    assert "vsearch" in combined or "uchime" in combined


### PR DESCRIPTION
## Summary
- add curated manuals for MAFFT, USEARCH/UCLUST, and VSEARCH along with a TF–IDF knowledge base
- implement a FastAPI service that exposes `/query` and `/healthz` endpoints backed by the retrieval engine
- provide pytest coverage, documentation, and helper scripts for working with the data

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb919127f48332be47b3aeb664dac8